### PR TITLE
refact : 좋아요시 likes 표시되도록 댓글, 게시글 수정

### DIFF
--- a/src/main/java/com/project/date/dto/response/LikeResponseDto.java
+++ b/src/main/java/com/project/date/dto/response/LikeResponseDto.java
@@ -1,5 +1,6 @@
 package com.project.date.dto.response;
 
+import com.project.date.model.Post;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 public class LikeResponseDto {
 
     private String imageUrl;
+    private Integer likes;
 
 
 }

--- a/src/main/java/com/project/date/service/LikeService.java
+++ b/src/main/java/com/project/date/service/LikeService.java
@@ -1,6 +1,7 @@
 package com.project.date.service;
 
 import com.project.date.dto.response.LikeResponseDto;
+import com.project.date.dto.response.PostResponseDto;
 import com.project.date.dto.response.ResponseDto;
 import com.project.date.jwt.TokenProvider;
 import com.project.date.model.*;
@@ -65,11 +66,16 @@ public class LikeService {
                     .build();
             likeRepository.save(postLike);
             post.addLike();
-            return ResponseDto.success("좋아요 성공");
+            return ResponseDto.success(
+                    LikeResponseDto.builder()
+                            .likes(postLike.getPost().getLikes())
+                            .build()
+            );
         } else {
             likeRepository.delete(liked);
             post.minusLike();
-            return ResponseDto.success("좋아요가 취소되었습니다.");
+            return ResponseDto.success(false);
+
         }
     }
 
@@ -111,11 +117,14 @@ public class LikeService {
                     .build();
             likeRepository.save(commentLike);
             comment.addLike();
-            return ResponseDto.success("좋아요 성공");
+            return ResponseDto.success(
+                    LikeResponseDto.builder()
+                            .likes(commentLike.getComment().getLikes()).build()
+            );
         } else {
             likeRepository.delete(liked);
             comment.minusLike();
-            return ResponseDto.success("좋아요가 취소되었습니다.");
+            return ResponseDto.success(false);
         }
     }
 


### PR DESCRIPTION
## 📰 개요
좋아요시 각 테이블의 likes가 표시되도록 수정

## 📰 작업사항
- 포스트와 댓글에 좋아요를 할때 count 컬럼인 likes가 표시되도록 수정하였습니다.
#66 